### PR TITLE
now spawns projectile based on screen center

### DIFF
--- a/Assets/Survival Island/Prefabs/Player.prefab
+++ b/Assets/Survival Island/Prefabs/Player.prefab
@@ -561,3 +561,4 @@ MonoBehaviour:
     UseConstant: 0
     ConstantValue: 0
     Variable: {fileID: 11400000, guid: 8c7e74e951ee19b4c9aa823055faa62c, type: 2}
+  cam: {fileID: 5215789215025711406}

--- a/Assets/Survival Island/Scripts/Weapons/ProjectileController.cs
+++ b/Assets/Survival Island/Scripts/Weapons/ProjectileController.cs
@@ -4,10 +4,12 @@ public class ProjectileController : MonoBehaviour
 {
     [SerializeField] private PrefabReference projectileToSpawn;
     [SerializeField] private FloatReference projectileFireForce;
+    [SerializeField] private Camera cam;
     // Called with unity events
     public void FireProjectile()
     {
-        GameObject projectile = Instantiate<GameObject>(projectileToSpawn.Value, transform.forward, transform.rotation);
+        Vector3 cameraCenter = cam.ViewportToWorldPoint(new Vector3(0.5f, 0.5f, 1));
+        GameObject projectile = Instantiate<GameObject>(projectileToSpawn.Value, cameraCenter, transform.rotation);
         Rigidbody rigidbody = projectile.GetComponent<Rigidbody>();
         if (!rigidbody) Debug.Log("A gun fired a bullet without a rigidbody");
         rigidbody?.AddForce(transform.forward * projectileFireForce.Value, ForceMode.Force);


### PR DESCRIPTION
Minor fix to make weapon bullets spawn based on screen center instead of player transform/rotation. This might need to be changed again once a crosshair is introduced..... or maybe not.